### PR TITLE
[MRG] :package: [pip] Build PyPI package for DataCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ This project is still under development. Please feel free to open an issue if yo
 
 ## Installation :construction:
 
+Easy install DataCI from [PyPI](https://pypi.org/project/ml-data-ci/)
+```shell
+pip install ml-data-ci
+```
+
 Manual install DataCI package from source code:
 ```shell
 pip install .

--- a/dataci/__init__.py
+++ b/dataci/__init__.py
@@ -5,4 +5,4 @@ Author: Li Yuanming
 Email: yuanmingleee@gmail.com
 Date: Feb 20, 2023
 """
-__version__ = '0.0.1'
+__version__ = '0.0.2'

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,27 @@ Date: May 11, 2023
 """
 from setuptools import setup, find_namespace_packages
 
+from dataci import __version__
+
+# Read the contents of README.md
+with open('README.md') as f:
+    long_description = f.read()
+
+# Read the requirements.txt
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setup(
-    name="dataci",
-    version='0.0.1',
+    name="ml-data-ci",
+    version=__version__,
+    description="A platform for tracking data-centric AI pipelines in dynamic streaming data",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author="Yuanming Li",
     author_email="yuanmingleee@gmail.com",
+    url='https://github.com/MLSysOps/DataCI',
     license='MIT',
+    keywords=['Data-centric AI', 'Streaming Data', 'MLOps', 'Pipeline Tracking', 'Data Versioning'],
     py_modules=['dataci'],
     packages=find_namespace_packages(exclude=['tests', 'exp', 'example']),
     install_requires=requirements,
@@ -23,4 +35,15 @@ setup(
         [console_scripts]
         dataci=dataci.command:cli
     """,
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Education',
+        'Intended Audience :: Financial and Insurance Industry',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Operating System :: POSIX :: Linux',
+    ],
 )


### PR DESCRIPTION
Close #4 

PyPI package name `dataci` has been taken, and any similar are not allowed to use (as PyPI's protection). We have to use `ml-data-ci` as the package name.

https://pypi.org/project/ml-data-ci/